### PR TITLE
Token based staking pool roundtrip test

### DIFF
--- a/staking-pool/tests/general.rs
+++ b/staking-pool/tests/general.rs
@@ -1,105 +1,67 @@
-extern crate env_logger;
-// #[war]
-#[allow(unused_imports)]
-#[macro_use]
-extern crate log;
-extern crate quickcheck;
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
 mod utils;
 
-use near_primitives::types::{AccountId, Balance};
-use near_sdk::json_types::U128;
-use serde::de::DeserializeOwned;
-use serde_json::json;
-use utils::{init_pool, ntoy, POOL_ACCOUNT_ID};
-
-use near_runtime_standalone::RuntimeStandalone;
-
-fn call_view<I: ToString, O: DeserializeOwned>(
-    runtime: &mut RuntimeStandalone,
-    account_id: &AccountId,
-    method: &str,
-    args: I,
-) -> O {
-    let args = args.to_string();
-    let result = runtime
-        .view_method_call(account_id, method, args.as_bytes())
-        .unwrap()
-        .0;
-    let output: O = serde_json::from_reader(result.as_slice()).unwrap();
-    output
-}
-
-fn call_pool<I: ToString, O: DeserializeOwned>(
-    runtime: &mut RuntimeStandalone,
-    method: &str,
-    args: I,
-) -> O {
-    call_view(runtime, &POOL_ACCOUNT_ID.into(), method, args)
-}
-
-#[allow(dead_code)]
-fn check_invariants(_runtime: &mut RuntimeStandalone, _users: &[AccountId]) {}
-
-#[quickcheck]
-fn qc_should_stake(initial_balance: Balance) -> bool {
-    let (mut runtime, root) = init_pool(23 * 10u128.pow(24));
-    let bob = root.create_external(&mut runtime, "bob".into(), ntoy(100));
-
-    // println!("{:?}", res);
-    dbg!(root.pool_ping(&mut runtime));
-    bob.pool_deposit(&mut runtime, initial_balance);
-    bob.pool_stake(&mut runtime, initial_balance);
-    let bob_stake: U128 = call_pool(
-        &mut runtime,
-        "get_account_staked_balance",
-        json!({"account_id": "bob"}),
+use near_primitives::types::Balance;
+use utils::{init_pool, ntoy, pool_account, wait_epoch, ExternalUser};
+#[test]
+fn multi_accounts_max_roundtrip() {
+    struct AccountStake {
+        pub account: ExternalUser,
+        pub staked: Balance,
+    };
+    let initial_pool_balance = ntoy(100);
+    let (ref mut runtime, ref root) = init_pool(initial_pool_balance);
+    assert_eq!(
+        pool_account(runtime).amount + pool_account(runtime).locked,
+        initial_pool_balance
     );
+    let mut accounts: Vec<AccountStake> = vec![];
+    let mut to_spend = 1;
+    let mut spent_total = 0;
+    let mut acc_no = 0;
+    loop {
+        to_spend = to_spend * 2;
 
-    assert_eq!(bob_stake, initial_balance.into());
+        acc_no += 1;
+        let acc = if let Ok(acc) =
+            root.create_external(runtime, format!("account_{}", acc_no), ntoy(30) + to_spend)
+        {
+            acc
+        } else {
+            break;
+        };
+        acc.pool_deposit(runtime, to_spend).unwrap();
+        spent_total += to_spend;
+        dbg!(spent_total);
+        let pool_acc = runtime.view_account(&"pool".into()).unwrap();
+        assert_eq!(
+            pool_acc.amount + pool_acc.locked,
+            initial_pool_balance + spent_total
+        );
+        acc.pool_stake(runtime, to_spend).unwrap();
+        accounts.push(AccountStake {
+            account: acc,
+            staked: to_spend,
+        });
+    }
 
-    // root.pool_deposit(&mut runtime, 10000);
-    // root.pool_stake(&mut runtime, 10000);
-    // wait_epoch(&mut runtime);
-    // reward_pool(&mut runtime, 1000);
-    // bob.pool_unstake(&mut runtime);
-    // let alice = root.create_external(&mut runtime, "alice".into(), ntoy(100));
+    for AccountStake { account, staked } in &accounts {
+        account.pool_unstake(runtime, *staked).unwrap();
+    }
+    wait_epoch(runtime);
+    runtime.produce_block().unwrap();
+    for AccountStake { account, staked } in &accounts {
+        account.pool_withdraw(runtime, *staked).unwrap();
+        assert_eq!(
+            account.account(runtime).amount,
+            ntoy(30) + *staked,
+            "Account: {:?}, staked: {:?}",
+            account.account_id(),
+            staked
+        );
+    }
 
-    // alice.
-    // alice.pool_deposit(&mut runtime, 10000);
-
-    // alice.pool_stake(&mut runtime, 1.into());
-    return true;
-}
-
-// fn reward_pool(runtime: &mut RuntimeStandalone, amount: Balance) {
-//     let mut pool_account = runtime.view_account(&POOL_ACCOUNT_ID.into()).unwrap();
-//     pool_account.locked += amount;
-//     runtime.force_account_update(POOL_ACCOUNT_ID.into(), &pool_account);
-// }
-
-// fn wait_epoch(runtime: &mut RuntimeStandalone) {
-//     let epoch_height = runtime.current_block().epoch_height;
-//     while epoch_height == runtime.current_block().epoch_height {
-//         runtime.produce_block().unwrap();
-//     }
-// }
-
-#[quickcheck]
-fn qc_test_deposit_withdraw_standalone(inital_balance: Balance) -> bool {
-    let deposit_amount = ntoy(inital_balance);
-    let (mut runtime, root) = init_pool(ntoy(100));
-    let bob = root.create_external(&mut runtime, "bob".into(), ntoy(100));
-    bob.pool_deposit(&mut runtime, deposit_amount);
-    let _res = bob.get_account_unstaked_balance(&runtime);
-
-    assert_eq!(_res, deposit_amount);
-    let _outcome = bob.pool_withdraw(&mut runtime, deposit_amount);
-    // match outcome.status {
-    //     ExecutionStatus::Failure(err) => panic!(err),
-    //     ExecutionStatus::SuccessValue(val) => info!("{}", String::from_utf8(val).unwrap()),
-    //     _ => ()
-    // };
-    bob.get_account_unstaked_balance(&runtime) == 0u128
+    assert_eq!(
+        pool_account(runtime).amount + pool_account(runtime).locked,
+        initial_pool_balance
+    );
 }

--- a/staking-pool/tests/quickcheck.rs
+++ b/staking-pool/tests/quickcheck.rs
@@ -1,0 +1,68 @@
+extern crate env_logger;
+#[allow(unused_imports)]
+#[macro_use]
+extern crate log;
+extern crate quickcheck;
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+mod utils;
+
+use near_primitives::types::{AccountId, Balance};
+use near_sdk::json_types::U128;
+use serde_json::json;
+use utils::{call_pool, init_pool, ntoy, wait_epoch};
+
+use near_runtime_standalone::RuntimeStandalone;
+
+#[allow(dead_code)]
+fn check_invariants(_runtime: &mut RuntimeStandalone, _users: &[AccountId]) {}
+
+#[quickcheck]
+fn qc_should_stake(initial_balance: Balance) -> bool {
+    let (mut runtime, root) = init_pool(23 * 10u128.pow(24));
+    let bob = root
+        .create_external(&mut runtime, "bob".into(), ntoy(100))
+        .unwrap();
+
+    bob.pool_deposit(&mut runtime, initial_balance).unwrap();
+    bob.pool_stake(&mut runtime, initial_balance).unwrap();
+    let bob_stake: U128 = call_pool(
+        &mut runtime,
+        "get_account_staked_balance",
+        json!({"account_id": "bob"}),
+    );
+
+    assert_eq!(bob_stake, initial_balance.into());
+
+    bob.pool_unstake(&mut runtime, initial_balance).unwrap();
+    wait_epoch(&mut runtime);
+    runtime.produce_block().unwrap();
+    let outcome = bob.pool_withdraw(&mut runtime, initial_balance);
+    if let Err(outcome) = outcome {
+        if initial_balance != 0 {
+            panic!("{:?}", outcome);
+        }
+    };
+    assert_eq!(bob.account(&mut runtime).amount, ntoy(100));
+    return true;
+}
+
+#[quickcheck]
+fn qc_test_deposit_withdraw_standalone(inital_balance: Balance) -> bool {
+    let deposit_amount = ntoy(inital_balance);
+    let (mut runtime, root) = init_pool(ntoy(100));
+    let bob = root
+        .create_external(&mut runtime, "bob".into(), ntoy(100))
+        .unwrap();
+    bob.pool_deposit(&mut runtime, deposit_amount).unwrap();
+    let _res = bob.get_account_unstaked_balance(&runtime);
+
+    assert_eq!(_res, deposit_amount);
+    let outcome = bob.pool_withdraw(&mut runtime, deposit_amount);
+    if let Err(outcome) = outcome {
+        if deposit_amount != 0 {
+            panic!("{:?}", outcome);
+        }
+    };
+    bob.get_account_unstaked_balance(&runtime) == 0u128
+}


### PR DESCRIPTION
- added multi_accounts_max_roundtrip test https://github.com/near/initial-contracts/blob/e37d68a0e9418d914f9ceb6397b86041f7f1cd43/staking-pool/tests/general.rs
- ExteralUser now returns Result<ExecutionOutcome, ExecutionOutcome>
- simulate unstake in ExteralUser

Miscs:
- moved quickcheck tests to a separate file