### PR TITLE
Add note regarding toolchain file and possibility of using nightly and stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 - [Whitelist Contract](./whitelist/)
 - [Staking Pool Factory](./staking-pool-factory/)
 - [Multisig contract](./multisig/)
+
+**Note**: observe the usage of the file `rust-toolchain` in the project root. This file contains toolchain information for nightly, while the `build.sh` scripts in respective contract subdirectories may override this with `cargo +stable`. Refer to the documentation on [the toolchain file and override precedence](https://github.com/rust-lang/rustup#the-toolchain-file). Keep in mind that the build scripts may use `stable` while `cargo test` may use nightly.


### PR DESCRIPTION
Some folks have missed the `rust-toolchain` file and its importance when writing tests for these files. At the time of this writing, tests need `nightly` while the `build.sh` files use `stable`.
I think it's important to make this clear in the readme so folks basing their contracts after this repository are aware of this.
I ran into someone today that assumed the whole project needed nightly because the tests needed it.